### PR TITLE
Fix app build process

### DIFF
--- a/apps/makefile
+++ b/apps/makefile
@@ -7,11 +7,12 @@ EXE_EXT := bin
 
 .PRECIOUS: $(BUILD_DIR)/%.elf
 
+# To add new app to be built, make sure that the app makefile builds a .elf file that is placed in BUILD_DIR
 APPS := $(DESTINATION_APP_DIR)/old_demo.$(EXE_EXT)\
 		$(DESTINATION_APP_DIR)/test_helper.$(EXE_EXT)\
 		$(DESTINATION_APP_DIR)/minesweeper.$(EXE_EXT)\
 		$(DESTINATION_APP_DIR)/brainfuck.$(EXE_EXT)\
-	  $(DESTINATION_APP_DIR)/new_test.$(EXE_EXT)\
+	  	$(DESTINATION_APP_DIR)/new_test.$(EXE_EXT)\
 		$(DESTINATION_APP_DIR)/calc.$(EXE_EXT)
 
 	

--- a/apps/new_test/makefile
+++ b/apps/new_test/makefile
@@ -2,4 +2,4 @@
 
 all:
 	@mkdir -p build/root/
-	nasm -fbin apps/new_test/main.asm -o build/root/new.bin
+	nasm -fbin apps/new_test/main.asm -o build/apps/new_test.elf

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -161,7 +161,7 @@ int main()
 
     set_print_output("/tty");
 
-    VFSFile* file = vfs_open_file("/new.bin", VFS_READ);
+    VFSFile* file = vfs_open_file("/new_test.bin", VFS_READ);
     if (file == NULL) {
         printf("Unable to open file\n");
         return 0;


### PR DESCRIPTION
To add new app to be built, make sure that the app makefile builds a .elf file that is placed in BUILD_DIR
And add it to the APPS variable following same style as other apps